### PR TITLE
Include "Reinstall your media player" as a troubleshooting step

### DIFF
--- a/documentation/troubleshooting.md
+++ b/documentation/troubleshooting.md
@@ -5,6 +5,7 @@ Follow this guide step-by-step to troubleshoot your issue.
 * [Check your Discord settings first](#check-your-discord-settings-first)
 * [Media players that don't work out of the box](#media-players-that-dont-work-out-of-the-box)
 * [Web versions of streaming services are not supported yet](#web-versions-of-streaming-services-are-not-supported-yet)
+* [Reinstall your media player](#reinstall-your-media-player)
 * [The player is detected, but still no status](#the-player-is-detected-but-still-no-status)
 * [Are you running Discord as administrator?](#are-you-running-discord-as-administrator)
 * [Other edge cases](#other-edge-cases)
@@ -59,6 +60,21 @@ what website the media is being played on,
 which makes it impossible to determine the source.
 Support for browsers will arrive
 [in a future update](https://github.com/ungive/discord-music-presence/issues/5).
+
+## Reinstall your media player
+
+if you are having issues with your media player being detected,
+you could try to reinstall it. You may need to remove
+all traces of your media player in `%APPDATA%` to
+reinstall properly.
+
+If you are using Spotify on Windows
+and your player is not detected, this
+should help. Remove all traces of 
+Spotify in `%APPDATA%\Spotify` and 
+try again.
+
+If that did not help, continue reading to the next section.
 
 ## The player is detected, but still no status
 


### PR DESCRIPTION
For users using Spotify on Windows, this is a valid solution if the user uninstalls Spotify, removes all data in `%APPDATA%/Spotify` and reinstalls. So, let's include that a step for those who might get success from it.

I mimicked the formatting of earlier steps. Feel free to propose changes if something is misspelt or not looking good.