### PR TITLE
General update to the "Supported media players" list

### DIFF
--- a/documentation/supported-media-players.md
+++ b/documentation/supported-media-players.md
@@ -1,15 +1,11 @@
 # Supported media players
 
 > [!WARNING]
-> This page is not kept up to date.
-> You can find an updated overview [here](https://musicpresence.pocha.moe/),
-> which is a site created by a community member.
-> Thank you [@mercurialworld](https://github.com/mercurialworld)!
-> The [additional notes](#additional-notes) below still apply though.
+> **Only the ["Additional Notes"](#additional-notes) and ["Players with known issues"](#players-with-known-issues) sections are actively maintained.**  
+> An accurate list of media players is available [here](https://musicpresence.pocha.moe/) - thank you to our community moderator [@mercurialworld](https://github.com/mercurialworld) for making this site!
 
 > [!NOTE]
-> If your media player is not detected,
-please visit the [**troubleshooting**](./troubleshooting.md) page
+> If your media player is not detected, please visit the [**troubleshooting**](./troubleshooting.md) page.
 
 ## Overview
 
@@ -55,148 +51,123 @@ please visit the [**troubleshooting**](./troubleshooting.md) page
 | Amazon Music              | :white_check_mark: :face_with_head_bandage: |     :white_check_mark:*     |                         :heavy_multiplication_x:                         |           ...            |
 | Apple Music               |             :white_check_mark:              |     :white_check_mark:      |                            :white_check_mark:                            |           ...            |
 | Apple Podcasts            |          :heavy_multiplication_x:           |     :white_check_mark:      |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
-| Cider<sup>7</sup>         |             :white_check_mark:              |     :white_check_mark:      |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
+| Cider<sup>1</sup>         |             :white_check_mark:              |     :white_check_mark:      |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
 | Deezer                    |             :white_check_mark:              |     :white_check_mark:*     |                         :heavy_multiplication_x:                         |           ...            |
-| Dopamine<sup>5</sup>      |             :white_check_mark:              |             ...             |                                   ...                                    |           ...            |
+| Dopamine<sup>2</sup>      |             :white_check_mark:              |             ...             |                                   ...                                    |           ...            |
 | foobar2000                |         :white_check_mark: :pencil:         |     :white_check_mark:      |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
 | Harmonoid                 |             :white_check_mark:              |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         |           ...            |
-| iTunes<sup>8</sup>        |         :white_check_mark: :pencil:         |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
+| iTunes<sup>3</sup>        |         :white_check_mark: :pencil:         |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
 | Jellyfin                  |         :white_check_mark: :wrench:         |             ...             |                                   ...                                    |           ...            |
 | MediaMonkey               | :white_check_mark: :face_with_head_bandage: |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
-| mpv                       |             :white_check_mark:              | :white_check_mark: :wrench: |                         :heavy_multiplication_x:                         |           ...            |
+| mpv                       |             :white_check_mark:              | :white_check_mark: :wrench: |                         :white_check_mark: :wrench:                         |           ...            |
 | MusicBee                  |         :white_check_mark: :pencil:         |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
-| Next-Player<sup>2</sup>   |             :white_check_mark:              |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
-| Nora<sup>3</sup>          |             :white_check_mark:              |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         |           ...            |
+| Next-Player<sup>4</sup>   |             :white_check_mark:              |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
+| Nora<sup>5</sup>          |             :white_check_mark:              |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         |           ...            |
 | Pocket Casts              |             :white_check_mark:              |     :white_check_mark:      |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
-| Podurama<sup>9</sup>      |         :white_check_mark: :wrench:         |             ...             |                                   ...                                    |           ...            |
-| Soundcloud<sup>4</sup>    |             :white_check_mark:              |             ...             |                                   ...                                    |           ...            |
+| Podurama<sup>6</sup>      |         :white_check_mark: :wrench:         |             ...             |                                   ...                                    |           ...            |
+| Soundcloud<sup>7</sup>    |             :white_check_mark:              |             ...             |                                   ...                                    |           ...            |
 | Spotify                   |             :white_check_mark:              |     :white_check_mark:      |                            :white_check_mark:                            |           ...            |
 | TIDAL                     |             :white_check_mark:              |     :white_check_mark:      | soon [#211](https://github.com/ungive/discord-music-presence/issues/211) |           ...            |
 | VLC Media Player          |    :white_check_mark: :pencil: :wrench:     |             ...             |                                   ...                                    |           ...            |
 | WACUP                     |         :white_check_mark: :wrench:         |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
-| Winamp<sup>6</sup>        |         :white_check_mark: :wrench:         |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
+| Winamp<sup>8</sup>        |         :white_check_mark: :wrench:         |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
 | Windows Media Player      | :white_check_mark: :face_with_head_bandage: |  :heavy_multiplication_x:   |                         :heavy_multiplication_x:                         | :heavy_multiplication_x: |
-| Yandex Music              |             :white_check_mark:              |       :grey_question:       |                             :grey_question:                              | :heavy_multiplication_x: |
-| YouTube Music<sup>1</sup> |             :white_check_mark:              |             ...             | soon [#212](https://github.com/ungive/discord-music-presence/issues/212) |           ...            |
-| YouTube<sup>9</sup>       |         :white_check_mark: :pencil:         |             ...             |                                   ...                                    |           ...            |
+| Yandex Music<sup>9</sup>              |             :white_check_mark:              |       :ballot_box_with_check:       |                             :ballot_box_with_check:                              | :heavy_multiplication_x: |
+| YouTube Music<sup>10</sup> |             :white_check_mark:              |             ...             | soon [#212](https://github.com/ungive/discord-music-presence/issues/212) |           ...            |
+| YouTube<sup>6</sup>       |         :white_check_mark: :pencil:         |             ...             |                                   ...                                    |           ...            |
 
 |          Symbol          | Meaning                                                                        |
 |:------------------------:|--------------------------------------------------------------------------------|
-|    :white_check_mark:    | This player is supported                                                       |
-|         :pencil:         | Needs additional configuration, please check the additional notes below        |
-|         :wrench:         | This player is supported, but only reports basic playback information          |
-| :face_with_head_bandage: | This player has known issues, see below                                        |
-| :ballot_box_with_check:  | This player is supported and should work, but wasn't explicitly tested         |
-|        :warning:         | Does not report any playback information unfortunately                         |
+|    :white_check_mark:    | Supported                                                                      |
+|         :pencil:         | Needs additional configuration, [see below](#additional-notes)                 |
+| :face_with_head_bandage: | Players with known issues, [see below](#players-with-known-issues)             |
+|         :wrench:         | Only reports basic playback information                                        |
+|        :warning:         | Does not report any playback information                                       |
 | :heavy_multiplication_x: | Not available on this operating system                                         |
-|     :grey_question:      | Not tested or not known to have a desktop application on this operating system |
-|           ...            | Not supported yet, but will likely be added in the future                      |
+| :ballot_box_with_check:  | Not officially tested                                                          |
+|           ...            | Will likely be supported in the future                                         |
 
-<sup>1</sup> Using [this](https://github.com/th-ch/youtube-music) unofficial desktop app  
-<sup>2</sup> From the developer "DryForest", [link](https://apps.microsoft.com/detail/9nblggh67n4f)  
-<sup>3</sup> [GitHub](https://github.com/Sandakan/Nora)  
-<sup>4</sup> [Official app](https://apps.microsoft.com/detail/9nvjbt29b36l) (only works on Windows 11)  
-<sup>5</sup> [GitHub](https://github.com/digimezzo/dopamine), works with Dopamine version 2 and 3  
-<sup>6</sup> Winamp only works when installed via the [WACUP](https://getwacup.com) installer  
-<sup>7</sup> Works on Windows 11 and Mac  
-<sup>8</sup> iTunes for Mac only runs on Mac versions older than the ones Music Presence supports  
-<sup>9</sup> Right now this only works by installing it via [WebCatalog](https://webcatalog.io)
+<sup>1</sup> Works on Windows 11 and Mac  
+<sup>2</sup> Made by "DigimezZo", available on [Github](https://github.com/digimezzo/dopamine); Versions 2 and 3 are supported  
+<sup>3</sup> iTunes for Mac is unsupported, [see below](#itunes)  
+<sup>4</sup> Made by "DryForest", available on [Microsoft Store](https://apps.microsoft.com/detail/9nblggh67n4f)  
+<sup>5</sup> Made by "Sandakan", available on [GitHub](https://github.com/Sandakan/Nora)  
+<sup>6</sup> Currently only supported if installed via [WebCatalog](https://webcatalog.io)
+<sup>7</sup> [Official app](https://apps.microsoft.com/detail/9nvjbt29b36l) (only supported on Windows 11)  
+<sup>8</sup> Winamp only works if installed via the [WACUP](https://getwacup.com) installer  
+<sup>9</sup> Available for Download on Debian, [official website](https://music.yandex.ru/download/)  
+<sup>10</sup> Using [this](https://github.com/th-ch/youtube-music) unofficial desktop app  
 
-## Additional notes
-
-### MusicBee
-
-MusicBee works well with this plugin:
-https://github.com/HenryPDT/mb_MediaControl
-
-The installation of such a plugin is required
-because otherwise MusicBee does not report what it is playing to Windows.
-Once you have installed and enabled it, Music Presence should detect Music Bee.
-
-### foobar2000
-
-While foobar2000 reports basic information out of the box,
-this plugin will add the album name and a progress bar to your status:
-https://github.com/ungive/foo_mediacontrol
-
-This is a fork of an old plugin which I have adapted
-to report missing song information.
-
-### AIMP
-
-AIMP requires this plugin to work:
-https://www.aimp.ru/forum/index.php?topic=63341
-
-Unfortunately this plugin does not report accurate playback information,
-but everything else seems to work just fine.
-
-### VLC
-
-VLC requires this plugin to work:
-https://github.com/spmn/vlc-win10smtc
-
-At the moment this plugin does not report any cover images,
-nor an accurate playback position.
-
-### iTunes
-
-On Windows you will need to run this helper program
-for iTunes to report currently playing media to Windows:
-https://github.com/thewizrd/iTunes-SMTC.
-After that it should be detected and you should see it in your status.
-
-iTunes on Mac is not supported as all versions for iTunes on Mac are too old.
-
-### Winamp
-
-For classic Winamp you might need this plugin,
-for the player to report the currently playing media to Windows:
-
-https://github.com/NanMetal/gen_smtc
-
-### mpv
-
-On Windows, mpv must either be run with `--media-controls=yes`
-or by setting `media-controls=yes` in your `mpv.conf` file.
-Otherwise mpv does not report currently playing media to Windows.
-
-On Mac, you must install and run mpv using an app bundle
-(file ending with `.app`),
-otherwise it cannot be detected at this time.
-Installing it with brew only installs a command line tool.
-If you need Music Presence to work with the command line tool only
-and you don't want to install an app bundle,
-please [open an issue](https://github.com/ungive/discord-music-presence/issues).
-
-If cover images are not showing or the above setting is not available,
-try updating mpv or installing a development version of mpv.
 
 ---
 
+
+## Additional Notes
+
+Windows and Linux offer specific tools for media players to report their playback information, named SMTC and MPRIS respectively.
+These are the essential features that allow Music Presence to function on Windows and Linux.
+
+Unfortunately, some players do not utilize this correctly, while others report nothing at all.
+For these cases, various people have written helper software to "close the gap".
+
+### MusicBee
+
+MusicBee requires [this plugin](https://github.com/HenryPDT/mb_MediaControl) to work.
+
+### foobar2000
+
+foobar2000 does not report all playback information out of the box.
+[This plugin](https://github.com/ungive/foo_mediacontrol) will add the album name and a progress bar to your status.
+
+### AIMP
+
+AIMP requires [this plugin](https://www.aimp.ru/forum/index.php?topic=63341) to work.
+While it generally works fine, it does apparently provide wrong playback information at times.
+
+### VLC
+
+VLC requires [this plugin](https://github.com/spmn/vlc-win10smtc) to work.
+As of right now, this plugin reports neither cover images, nor an accurate playback position.
+
+### iTunes
+
+iTunes on Windows requires [this helper program](https://github.com/thewizrd/iTunes-SMTC) to work.
+
+iTunes on Mac is considered legacy software and therefore no longer supported.
+
+### Winamp
+
+Winamp Classic requires [this plugin](https://github.com/NanMetal/gen_smtc) to work.
+
+### mpv
+
+On Windows, mpv does not report playback information by default.
+You must either run mpv with `--media-controls=yes` or by setting `media-controls=yes` in your `mpv.conf` file.
+If cover images are not showing or the above setting is not available, try updating mpv or installing a development version of mpv.
+
+On Mac, you must install and run mpv using an app bundle (file ending with `.app`), otherwise it cannot be detected as of right now.
+Installing it with brew only installs a command line tool. If you need Music Presence to work with the command line tool only
+and you don't want to install an app bundle, please [open an issue](https://github.com/ungive/discord-music-presence/issues).
+
+On Linux, mpv requires [this plugin](https://github.com/hoyon/mpv-mpris) to work.
+
 ## Players with known issues
 
-> These are issues with the ***media players themselves***,
-> not with Music Presence!
-> Affected players are sometimes reporting
-> incorrect song metadata or playback information,
-> we unfortunately can't do much about that.
+> Some media players are reporting incorrect song metadata or playback information.
+> These are issues with the ***media players themselves***, not with Music Presence!
+> We have little to no control over these cases.
 
-> Also note that the information here was gathered some time ago
-> and might be outdated for some media players.
-> Contributions with updated information are very welcome.
+> This information may be outdated at any later date; contributions with updated information are very welcome!
 
 ### Not working randomly
 
-Some players stop reporting song information arbitrarily at some point.
+Some players may stop reporting song information arbitrarily at some point.
 
 - Windows Media Player on Windows
 
 ### Incorrect song metadata
 
-The following players sometimes report incorrect song information,
-like a missing artist, a scrambled song name or no information at all,
-which might cause some songs to not be shown in your status
-or only with incomplete information.
+Some players may report incorrect song information (e.g. missing artist, scrambled song name) or no information at all.
 
 - Amazon Music on Windows
 
@@ -204,10 +175,7 @@ or only with incomplete information.
 
 #### No precise playback position
 
-These players do not report a precise playback position
-and will only show how much time has elapsed since starting the song,
-instead of adjusting correctly,
-depending on which playback position you jump to in the song.
+Some players do not report any precise playback position, only how much time has elapsed since starting the song.
 
 - Amazon Music on Windows
 - Amazon Music on Mac
@@ -225,20 +193,15 @@ depending on which playback position you jump to in the song.
 
 #### Incorrect playback position timestamp
 
-These media players report a playback position
-(which might also be imprecise, see above),
-but they also say e.g. "this playback position is from 10 minutes ago"
-even though the media just started playing and it should say something like
-"this playback position is from a few seconds ago".
-This only becomes a problem when pausing the song and continuing it later,
-which might report something like "13:04 elapsed"
-for a song that's 3 minutes long.
+Some players report their playback position with an outdated “as of” timestamp.
+This will show up as an elapsed timer that’s wildly ahead of reality (e.g., “13:04 elapsed” right after resuming a 3-minute track).
+It’s most noticeable after pausing and later resuming: Discord keeps the stale timestamp, so the counter jumps.
 
 - Deezer on Mac
 
 #### Missing album cover image
 
-These players do not report the album cover to the operating system.
+Some players do not report the album cover of any given track.
 
 - MediaMonkey on Windows
 - VLC on Windows


### PR DESCRIPTION
# Changes made

### General
- updated the header warning to reflect mercurial's promotion to community moderator

### Media Player List
- added support for mpv and Yandex Music
- general writing improvements to the key of the media player table
- numerically sorted media player list annotations
- unified writing style for media player list annotations
- added annotation for Yandex Music

### Additional Notes
- added general explanation for usage of SMTC & MPRIS for clarity
- unified writing style for all "helper program required" notes

### Players with known issues
- reduced overall explanation length

---

## Comment
As mentioned on Discord, this would probably fare better as a GitHub wiki in the long term...
I might look into it this weekend.