### PR TITLE
Update VLC plugin documentation

### DIFF
--- a/documentation/supported-media-players.md
+++ b/documentation/supported-media-players.md
@@ -135,8 +135,7 @@ but everything else seems to work just fine.
 VLC requires this plugin to work:
 https://github.com/spmn/vlc-win10smtc
 
-At the moment this plugin does not report any cover images,
-nor an accurate playback position.
+At the moment this plugin does not report an accurate playback position.
 
 ### iTunes
 
@@ -241,6 +240,5 @@ for a song that's 3 minutes long.
 These players do not report the album cover to the operating system.
 
 - MediaMonkey on Windows
-- VLC on Windows
 - Podurama on Windows
 - Amazon Music on Windows


### PR DESCRIPTION
EDIT: Never mind, I just noticed that the [other pull request](https://github.com/ungive/discord-music-presence/pull/397#discussion_r2290460769) also covered this.
Since September 17, 2024 (https://github.com/ungive/discord-music-presence/commit/87242f4d34cef77c1c4aad00377b9540cbef9f4a), when this section of the docs was written, the vlc-win10smtc plugin has added album art reporting.

<img width="267" height="110" alt="image" src="https://github.com/user-attachments/assets/b684c64c-2722-48f7-91af-dfd982b81a43" />
